### PR TITLE
fix: ignore files generated on mvn package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ buildNumber.properties
 *~
 
 *.db
+
+gtfs-realtime-validator-webapp/gtfsrthsql.*
+gtfs-realtime-validator-webapp/http*
+
+


### PR DESCRIPTION
**Summary:**

On `mvn package` the following files are generated but not ignored in `.gitignore`
```
	gtfs-realtime-validator-webapp/gtfsrthsql.lobs
	gtfs-realtime-validator-webapp/gtfsrthsql.properties
	gtfs-realtime-validator-webapp/gtfsrthsql.script
	gtfs-realtime-validator-webapp/https%3A%2F%2Fgithub.com%2FMobilityData%2Fgtfs-realtime-validator%2Fraw%2Fmaster%2Fgtfs-realtime-validator-webapp%2Fsrc%2Ftest%2Fresources%2Fbadgtfs.zip
	gtfs-realtime-validator-webapp/https%3A%2F%2Fgithub.com%2FMobilityData%2Fgtfs-realtime-validator%2Fraw%2Fmaster%2Fgtfs-realtime-validator-webapp%2Fsrc%2Ftest%2Fresources%2Fbullrunner-gtfs.zip
```

**Expected behavior:** 

Do not expect to have to avoid committing these generated files, should be in `.gitignore`


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s) (N/A)
